### PR TITLE
Fix `hook.id` permission checking

### DIFF
--- a/src/hooks/check-permissions.js
+++ b/src/hooks/check-permissions.js
@@ -91,7 +91,7 @@ export default function checkPermissions (options = {}) {
       // If we are requesting a resource with an ID add those
       // as permissions checks.
       if (!!id || id === 0) {
-        perms = permissions.concat([
+        perms = perms.concat([
           `${namespace}:*:${id}`,
           `${namespace}:${method}:${id}`
         ]);

--- a/test/hooks/check-permissions.test.js
+++ b/test/hooks/check-permissions.test.js
@@ -110,6 +110,18 @@ describe('hooks:checkPermissions', () => {
           it('sets hook.params.permitted', () => {
             hook.params.user.permissions = ['admin'];
             options.group = 'admin';
+            delete options.service;
+            return checkPermissions(options)(hook).then(hook => {
+              expect(hook.params.permitted).to.equal(true);
+            });
+          });
+        });
+        describe('when entity has matched role permission', () => {
+          it('sets hook.params.permitted', () => {
+            hook.params.user.role = 'admin';
+            options.field = 'role';
+            options.roles = ['admin'];
+            delete options.service;
             return checkPermissions(options)(hook).then(hook => {
               expect(hook.params.permitted).to.equal(true);
             });


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Problem

I just noticed that the new permission strategy just allows everything as long as `hook.id` is defined.

### Other Information

Also added `group` and `roles` permission checking tests. Although, I'm wondering what `group` is for.
Slack message reported:
https://feathersjs.slack.com/archives/authentication/p1480055259000644