### PR TITLE
Allow usage as global hook for app

### DIFF
--- a/src/hooks/check-permissions.js
+++ b/src/hooks/check-permissions.js
@@ -33,6 +33,8 @@ export default function checkPermissions (options = {}) {
       namespaces = [options.group];
     } else if (options.roles) {
       namespaces = options.roles;
+    } else if (hook.path && options.globalHook) {
+      namespaces = [hook.path];
     }
 
     debug('Running checkPermissions hook with options:', options);

--- a/test/hooks/check-permissions.test.js
+++ b/test/hooks/check-permissions.test.js
@@ -11,6 +11,7 @@ describe('hooks:checkPermissions', () => {
       id: 1,
       type: 'before',
       method: 'get',
+      path: 'somepath',
       app: {
         get: () => {}
       },


### PR DESCRIPTION
Add `options.globalHook` so it can be used globally

### Summary

This PR allows the check-permission hook to be used as a global hook, see use case below.

If so, please mention them to keep the conversations linked together.

### Other Information

This allows `check-permissions` to be used like this:

```javascript 
// this is globalHooks.js which is used as  app.hooks({before: globalHooks.before});

const _ = require('lodash');
const permissions = require('feathers-permissions').hooks;   
/*
Put publicPaths into your config like:
  "publicPaths": [
    "authentication", // auk
    "auth/local", // 1.0
    "somePublicService"
  ],
*/
function publicPath (hook) {
  return _.every(hook.app.get('publicPaths'), function(path) {
    return hook.path != path;
  });
}

exports.before = {
  all: [
    function (hook) {
      if (!hook.path) {
        // Legacy Compability
        hook.path = Object.keys(hook.app.services).find(name => hook.app.services[name] === this);
      }
    },
    hooks.iff(
      (hook) => publicPath(hook),
      auth.hooks.authenticate('jwt')
    ),
    hooks.iff(
      (hook) => publicPath(hook),
      permissions.checkPermissions({globalHook: true})
    ),
    hooks.iff(
      (hook) => publicPath(hook),
      permissions.isPermitted()
    )
  ],
  find: [],
  get: [],
  create: [],
  update: [],
  patch: [],
  remove: []
};
```